### PR TITLE
Add circle.yml deploy process.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,27 @@
+machine:
+  node:
+    version: 4.4.7
+
+dependencies:
+  override:
+    - npm install -g aws-cli
+
+test:
+  override:
+    - echo 'No tests.'
+  post:
+    # For Precog.
+    - cp -R lib index.html main.js scene.yaml $CIRCLE_ARTIFACTS
+
+# For hosting on mapzen.com.
+deployment:
+  production:
+    branch: master
+    commands:
+      - aws s3 sync $CIRCLE_ARTIFACTS $AWS_PROD_DESTINATION
+      # - aws s3 sync $CIRCLE_ARTIFACTS $AWS_PROD_DESTINATION --delete
+  staging:
+    branch: gh-pages
+    commands:
+      - aws s3 sync $CIRCLE_ARTIFACTS $AWS_DEV_DESTINATION
+      # - aws s3 sync $CIRCLE_ARTIFACTS $AWS_DEV_DESTINATION --delete


### PR DESCRIPTION
This will allow pushes to the main `gh-pages` branch to also be deployed to `dev.mapzen.com/tangram/view/`. We should be able to test tangram-frame concurrently in GitHub pages mode and in the view mode so we can iron out any issues, security problems, etc (and determine whether tangram-frame will need to be forked for production, for example).

The settings also allow the `master` branch to push to production, as it is for Tangram Play. Since there is no master branch, this won't happen, but we can flip that switch when we are ready.

One side effect of adding `circle.yml` is that we also now get Precog on this for free: https://precog.mapzen.com/tangrams/tangram-frame/

cc @meetar @bcamper @sleepylemur  
