### PR TITLE
Support ?scene= query parameter

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,7 +20,10 @@ load = (function load() {
     var scene_lib = '0.8';
     var build = "min";
     query = parseQuery(window.location.search.slice(1));
-    if (query.url) {
+    if (query.scene) {
+        // ?scene= is the parameter used by Tangram Play
+        scene_url = query.scene;
+    } else if (query.url) {
         scene_url = query.url;
     }
     if (query.lib) {
@@ -85,7 +88,7 @@ function parseGist(url, lib_url) {
     });
 }
 
-function loadLib(url) {    
+function loadLib(url) {
     var lib_script = document.getElementById("tangramjs");
     lib_script.src = url;
 }
@@ -236,4 +239,3 @@ function initMap() {
     }());
     MPZN.bug(bugOptions);
 }
-


### PR DESCRIPTION
This allows changing a Tangram Play url such as:

https://mapzen.com/tangram/play/?scene=https%3A%2F%2Fmapzen.com%2Fcarto%2Fcinnabar-style%2F2.0%2Fcinnabar-style.yaml#6.2820/39.884/-78.285

by modifying just the "play" to "view" and it will work.

My editor was also aggressive about trimming trailing spaces, I apologize.
