### PR TITLE
Only allow tangram to be loaded from white-listed hosts

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,9 +36,8 @@ load = (function load() {
 
     if (scene_lib.indexOf("/") > -1) {
         // assume it's a full path
-        // check that it's a tangram library
-        if (scene_lib.substr(scene_lib.length - 17) == '/tangram.debug.js' ||
-            scene_lib.substr(scene_lib.length - 15) == '/tangram.min.js') {
+        // check that it's a tangram library on a whitelisted domain
+        if (scene_lib.match(/^https?:\/\/(.*mapzen.com|localhost)(:[0-9]+)?\/.*tangram\.(min|debug)\.js$/)) {
             var lib_url = scene_lib;
         } else {
             // noooo you don't

--- a/main.js
+++ b/main.js
@@ -46,7 +46,7 @@ load = (function load() {
             scene_lib = default_scene_lib;
         }
     }
-    else if (scene_lib.indexOf("/") == -1) {
+    if (scene_lib.indexOf("/") == -1) {
         // assume it's a version # only
         lib_url = "https://mapzen.com/tangram/"+scene_lib+"/tangram."+build+".js";
     }


### PR DESCRIPTION
This restricts the specific tangram lib to a white-listed host, either:
- `*.mapzen.com` (e.g. can use `precog.mapzen.com`)
- `localhost`
