### PR TITLE
Revise API key check to allow keys with less than 7 character suffix

### DIFF
--- a/main.js
+++ b/main.js
@@ -347,9 +347,8 @@ function displayNoWebGLMessage() {
 
 // A basic check to see if an api key string looks like a valid key. Not
 // *is* a valid key, just *looks like* one.
-// TODO: it's possible some legacy keys have 6 digits instead of 7; check with Evan
 function isValidMapzenApiKey(string) {
-    return (typeof string === 'string' && string.match(/[-a-z]+-[0-9a-zA-Z_-]{7}/));
+    return Boolean(typeof string === 'string' && string.match(/^[-a-z]+-[0-9a-zA-Z_-]{5,7}$/));
 }
 
 // Adapted from Tangram Play's own automatic API-key insertion code


### PR DESCRIPTION
Based on this discussion here: https://github.com/mapzen/mapzen.js/pull/367

A test suite for this function now exists in Tangram Play (https://github.com/tangrams/tangram-play/commit/da2328353d7895c2fcf01b5e8fd2eb0ed96148fc#diff-0f908e1f5e75a5e4b9da71014586b4b1L22) (and this is also possibly a candidate as a small utility module for a mapzen-functionality client library)